### PR TITLE
fix alias_ssl_status type

### DIFF
--- a/aliases.go
+++ b/aliases.go
@@ -38,7 +38,7 @@ type Alias struct {
 	Updated   string  `json:"alias_updated"`
 	Name      string  `json:"alias_data"`
 	SSLExpire int     `json:"alias_ssl_expire,omitempty"`
-	SSLStatus int     `json:"alias_ssl_status"`
+	SSLStatus string  `json:"alias_ssl_status"`
 	SSLType   *string `json:"alias_ssl_type"`
 }
 


### PR DESCRIPTION
На данный момент используется тип int, тогда как фактически облако отдаёт string.